### PR TITLE
Added comments about current Jupyter image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "3"
 services:
   datascience-notebook:
-      image: jupyter/datascience-notebook
+      # Refer to https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html
+      image: jupyter/datascience-notebook # Approximately ~4.78GB in size
       volumes:
         - ./notebooks:/home/jovyan/
       ports:


### PR DESCRIPTION
Jupyter has excellent documentation about selecting the base Docker image you would like to work with.

Please refer to their guide at https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html for more information