### PR TITLE
Let's make life easier and link to Docker Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project has been created to explore working with [Jupyter](https://jupyter.
 
 ## Getting started
 
-The easiest way to use this repo is to have [Docker](https://www.docker.com) installed and configured on your development machine.
+The easiest way to use this repo is to have [Docker Desktop for Mac/Windows](https://www.docker.com/products/docker-desktop) installed and configured on your development machine.
 
 Once this is complete, you can spin up the project by running:
 


### PR DESCRIPTION
Instead of just dumping people off to install Docker on their development environment, let's make life easier and direct them to Docker for Desktop instead.